### PR TITLE
Added workspace installation how-to. Added commandline options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,33 @@ What do we count:
 * all images embedded as <img> tags
 
 TODO:
-* count images embedded as background
+* count images embedded as background* 
+
+How-to compile a project
+=====
+
+Install golang to your system.
+For Ubuntu 12-14 LTS your need to run
+```sh
+sudo apt-get install golang
+```
+
+Clone current repo to some directory. Let it be ```/var/www/website-size-scan```
+
+Now do prepare workspace
+```sh
+export GOPATH=/var/www/website-size-scan/
+```
+
+Download neede dependency
+```sh
+cd /var/www/website-size-scan/
+go get github.com/PuerkitoBio/goquery
+```
+
+Now you are ready for compiling go code within workspace directory.
+For current project run a command
+```sh
+go build scan-website.go
+```
+and you'll get executable program nearby, named ```scan-website```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Website pages size scanner
 
-Script takes file with list of links and estimates size of each page writing to outpt file in CSV format.
+Script takes file with list of links and estimates size of each page writing to output file in CSV format.
 
 What do we count:
 * size of the html of the page

--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ For current project run a command
 go build scan-website.go
 ```
 and you'll get executable program nearby, named ```scan-website```
+
+Video how-to
+=====
+
+Use this link to watch how-to compile go programs
+https://www.youtube.com/watch?v=XCsL89YtqCs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Now do prepare workspace
 export GOPATH=/var/www/website-size-scan/
 ```
 
-Download neede dependency
+Download needed dependency
 ```sh
 cd /var/www/website-size-scan/
 go get github.com/PuerkitoBio/goquery

--- a/README.md
+++ b/README.md
@@ -35,11 +35,24 @@ go get github.com/PuerkitoBio/goquery
 Now you are ready for compiling go code within workspace directory.
 For current project run a command
 ```sh
-go build scan-website.go
+go build
 ```
-and you'll get executable program nearby, named ```scan-website```
+and you'll get executable program nearby, named ```website-size-scan```
 
-Video how-to
+Command line options for compiled program
+=====
+
+```sh
+# ./website-size-scan -h
+Usage of ./website-size-scan:
+  -baseUrl="http://www.example.com": Will be used to adjust relative paths.
+  -count=100: Number of URLs in the input file
+  -inputFile="./links.csv": Will be used as source file for links.
+  -outputFile="./output.csv": Will be used as output for results.
+  -workers=5: Number of workers. Be careful with this number. Big number will put your site down.
+```
+
+Video how-to "going"
 =====
 
 Use this link to watch how-to compile go programs

--- a/scan-website.go
+++ b/scan-website.go
@@ -9,14 +9,26 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"flag"
 )
 
+var count int
+var workers int
+var baseUrl string
+var inputFile string
+var outputFile string
+
+func init() {
+	flag.IntVar(&count, "count", 100, "Number of URLs in the input file")
+	flag.IntVar(&workers, "workers", 5, "Number of workers. Be careful with this number. Big number will put your site down.")
+	flag.StringVar(&baseUrl, "baseUrl", "http://www.example.com", "Will be used to adjust relative paths.")
+	flag.StringVar(&inputFile, "inputFile", "./links.csv", "Will be used as source file for links.")
+	flag.StringVar(&outputFile, "outputFile", "./output.csv", "Will be used as output for results.")
+
+	flag.Parse()
+}
+
 func main() {
-	count := 100  // Number of URLs in the input file.
-	workers := 5  // Be careful with this number. Big number will put your site down.
-	baseUrl := "http://www.example.com"; // Will be used to adjust relative paths.
-	inputFile := "/home/ygerasimov/go/links.csv"
-	outputFile := "/home/ygerasimov/go/output.csv"
 
 	input := make(chan string)
 	output := make(chan string)


### PR DESCRIPTION
``` sh
# ./website-size-scan -h
Usage of ./website-size-scan:
  -baseUrl="http://www.example.com": Will be used to adjust relative paths.
  -count=100: Number of URLs in the input file
  -inputFile="./links.csv": Will be used as source file for links.
  -outputFile="./output.csv": Will be used as output for results.
  -workers=5: Number of workers. Be careful with this number. Big number will put your site down.
```
